### PR TITLE
Plan picker component

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@preact/signals": "^1.1.5",
     "chart.js": "^4.3.0",
+    "classnames": "^2.3.2",
     "date-fns": "^2.30.0",
     "preact": "^10.11.3"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import {
   ChartComponent,
   MoneyBackComponent,
   ReviewsComponent,
-  PlanPickerComponent,
+  PlanPicker,
   ProgressBarComponent,
   LoaderComponent,
   LoaderSetComponent,
@@ -28,6 +28,9 @@ const implementedComponents = ['List', 'PlanPicker'];
 
 export function App() {
   const selectedComponent = useSignal('PlanPicker');
+  const state = useSignal({
+    plan: '',
+  });
 
   return (
     <main class="h-screen touch-pan-y overflow-x-hidden m-auto sm:px-5 py-10 flex justify-center">
@@ -57,7 +60,18 @@ export function App() {
           { selectedComponent.value === 'Chart' && <ChartComponent /> }
           { selectedComponent.value === 'MoneyBack' && <MoneyBackComponent /> }
           { selectedComponent.value === 'Reviews' && <ReviewsComponent /> }
-          { selectedComponent.value === 'PlanPicker' && <PlanPickerComponent {...planPicker} /> }
+          { selectedComponent.value === 'PlanPicker' && (
+            <PlanPicker
+              {...planPicker}
+              value={state.value.plan}
+              onUpdate={(planId) => {
+                state.value = {
+                  ...state.value,
+                  plan: planId as string,
+                };
+              }}
+            />
+          ) }
           { selectedComponent.value === 'ProgressBar' && <ProgressBarComponent /> }
           { selectedComponent.value === 'Loader' && <LoaderComponent /> }
           { selectedComponent.value === 'LoaderSet' && <LoaderSetComponent /> }

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,0 +1,7 @@
+export enum Currency {
+  USD = 'USD'
+}
+
+export const CURRENCY_SIGN = {
+  [Currency.USD]: '$',
+};

--- a/src/data.ts
+++ b/src/data.ts
@@ -1,3 +1,7 @@
+import { Currency } from './common/constants';
+import { PaymentPeriod } from './tasks/plan-picker';
+
+
 export const list = {
   title: 'Your personal\nstyle elevating plan',
   items: [
@@ -20,6 +24,50 @@ export const list = {
     {
       icon: 'bag',
       text: 'Save money and time on shopping',
+    },
+  ],
+};
+
+export const planPicker = {
+  title: 'Choose your plan',
+  defaultPlan: '1',
+  plans: [
+    {
+      id: '1',
+      label: '12 Week plan',
+      oldPrice: 9.99,
+      price: 6.93,
+      currency: Currency.USD,
+      priceBadge: {
+        period: 'day' as PaymentPeriod,
+        price: 0.99,
+        oldPrice: 1.42,
+      },
+    },
+    {
+      id: '2',
+      label: 'Welcome Offer',
+      oldPrice: 29.99,
+      price: 17.99,
+      currency: Currency.USD,
+      planBadgeText: 'Most popular',
+      priceBadge: {
+        period: 'day' as PaymentPeriod,
+        price: 0.58,
+        oldPrice: 0.99,
+      },
+    },
+    {
+      id: '3',
+      label: 'Annual plan',
+      oldPrice: 59.99,
+      price: 29.99,
+      currency: Currency.USD,
+      priceBadge: {
+        period: 'day' as PaymentPeriod,
+        price: 0.33,
+        oldPrice: 0.71,
+      },
     },
   ],
 };

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -1,23 +1,24 @@
-import { ChartComponent } from "./chart"
-import { ListComponent } from "./list"
-import { MoneyBackComponent } from "./money-back"
-import { ReviewsComponent } from './reviews'
-import { PlanPickerComponent } from "./plan-picker"
-import { PaymentMethodComponent } from "./payment-method"
-import { LoaderComponent } from "./loader"
-import { LoaderSetComponent } from "./loader-set"
-import { ProgressBarComponent } from "./progress-bar"
-import { RatingComponent } from "./rating"
+import { ChartComponent } from './chart';
+import { ListComponent } from './list';
+import { MoneyBackComponent } from './money-back';
+import { ReviewsComponent } from './reviews';
+import { PlanPicker } from './plan-picker';
+import { PaymentMethodComponent } from './payment-method';
+import { LoaderComponent } from './loader';
+import { LoaderSetComponent } from './loader-set';
+import { ProgressBarComponent } from './progress-bar';
+import { RatingComponent } from './rating';
+
 
 export {
-    ChartComponent,
-    ListComponent,
-    MoneyBackComponent,
-    ReviewsComponent,
-    PlanPickerComponent,
-    PaymentMethodComponent,
-    LoaderComponent,
-    LoaderSetComponent,
-    ProgressBarComponent,
-    RatingComponent
-}
+  ChartComponent,
+  ListComponent,
+  MoneyBackComponent,
+  ReviewsComponent,
+  PlanPicker,
+  PaymentMethodComponent,
+  LoaderComponent,
+  LoaderSetComponent,
+  ProgressBarComponent,
+  RatingComponent,
+};

--- a/src/tasks/plan-picker/PlanItem.tsx
+++ b/src/tasks/plan-picker/PlanItem.tsx
@@ -1,0 +1,120 @@
+import cs from 'classnames';
+import { Currency } from '@/common/constants';
+import { formatPrice } from '@/utils/money';
+
+import styles from './styles.module.css';
+import { PriceBadge } from './PriceBadge';
+
+
+export type PaymentPeriod = 'day' | 'week' | 'month' | 'year';
+
+export type Plan = {
+  id: string
+  label: string
+  oldPrice?: number
+  price: number
+  planBadgeText?: string
+  currency: string
+  priceBadge: {
+    period: PaymentPeriod;
+    price: number
+    oldPrice?: number
+  }
+}
+
+export interface PlanItemProps { 
+  plan: Plan; 
+  selected: boolean; 
+  onSelect: () => void;
+}
+
+const Offer = ({ title, price, oldPrice, currency }: {
+  title: string;
+  price: number;
+  oldPrice?: number;
+  currency: Currency;
+}) => {
+  return (
+    <div class='left flex flex-col gap-1.5'>
+      <div class='font-bold leading-normal'>
+        { title }
+      </div>
+      <div class='prices flex gap-1 text-sm'>
+        { oldPrice && (
+          <span class={styles.oldPrice}>
+            { formatPrice(oldPrice, currency as Currency) }
+          </span>
+        ) }
+        <span>
+          { formatPrice(price, currency as Currency) }
+        </span>
+      </div>
+    </div>
+  );
+};
+
+const PeriodOffer = ({ period, price, oldPrice, currency }: {
+  period: PaymentPeriod;
+  price: number;
+  oldPrice?: number;
+  currency: Currency;
+}) => {
+  return (
+    <div class='right flex items-end gap-1'>
+      <div>
+        { oldPrice && (
+          <span class={cs(styles.oldPrice, styles.oldPeriodPrice)}>
+            { formatPrice(oldPrice, currency as Currency) }
+          </span>
+        ) }
+      </div>
+      <PriceBadge price={price} period={period} currency={currency} />
+    </div>
+  );
+};
+
+export const PlanItem = ({ plan: {
+  label, 
+  oldPrice,
+  price,
+  priceBadge,
+  planBadgeText,
+  ...plan
+}, onSelect, selected }: PlanItemProps) => {
+  const currency = plan.currency as Currency;
+  const hasBadge = !!planBadgeText;
+  const handleClick = () => onSelect();
+  
+  return (
+    <div
+      onClick={selected ? undefined : handleClick}
+      class={cs(styles.plan, 'flex relative cursor-pointer justify-between p-4 rounded-md border-solid', {
+        [styles.withBadge]: hasBadge,
+        [styles.selected]: selected,
+      })}
+    >
+      { hasBadge && (
+        <div
+          class={cs('absolute bg-red-400 text-white py-1 px-4 -top-3 -left-0.5 rounded-lg rounded-bl-none uppercase font-bold text-[10px]', {
+            ['bg-red-400']: !selected,
+            ['bg-accent']: selected,
+          })}
+        >
+          { planBadgeText }
+        </div>
+      ) }
+      <Offer 
+        title={label}
+        price={price}
+        oldPrice={oldPrice}
+        currency={currency}
+      />
+      <PeriodOffer 
+        period={priceBadge.period}
+        price={priceBadge.price}
+        oldPrice={oldPrice}
+        currency={currency}
+      />
+    </div>
+  );
+};

--- a/src/tasks/plan-picker/PlanPicker.tsx
+++ b/src/tasks/plan-picker/PlanPicker.tsx
@@ -1,0 +1,28 @@
+import { Plan, PlanItem } from './PlanItem';
+
+
+export type PlanPickerProps = {
+  title?: string
+  defaultPlan?: Plan['id']
+  plans: Plan[]
+} & Actionable
+
+export function PlanPicker({ title, defaultPlan, plans, value, onUpdate }: PlanPickerProps) {
+  const selectedPlan = value ?? defaultPlan;
+
+  return (
+    <div class='flex flex-col gap-5'>
+      <div class='font-bold text-xl text-center'>
+        { title }
+      </div>
+      { plans.map(plan => (
+        <PlanItem 
+          key={plan.id} 
+          plan={plan}
+          selected={plan.id === selectedPlan}
+          onSelect={() => onUpdate(plan.id)}
+        />
+      )) }
+    </div>
+  );
+}

--- a/src/tasks/plan-picker/PriceBadge.tsx
+++ b/src/tasks/plan-picker/PriceBadge.tsx
@@ -1,0 +1,42 @@
+import cs from 'classnames';
+import { CURRENCY_SIGN, Currency } from '@/common/constants';
+import styles from './styles.module.css';
+
+
+const PriceBadgeSVG = ({ bg = '#111111', bgOpacity = '0.08', className = '' }) => {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="104" height="46" viewBox="0 0 104 46" fill="none" class={className}>
+      <path d="M13.5715 3.25036C15.0796 1.20634 17.4688 0 20.009 0H96C100.418 0 104 3.58172 104 8V38C104 42.4183 100.418 46 96 46H20.009C17.4689 46 15.0796 44.7937 13.5715 42.7496L2.50435 27.7496C0.420961 24.9259 0.420962 21.0741 2.50435 18.2504L13.5715 3.25036Z" fill={bg} fill-opacity={bgOpacity} />
+    </svg>
+  );
+};
+
+export const PriceBadge = ({ price, currency, period }: {
+  price: number;
+  period: string;
+  currency: Currency;
+}) => {
+  const intPrice = Math.floor(price);
+  const decimalDigits = String(price - intPrice).substring(2, 4);
+
+  return (
+    <div class={cs(styles.priceBadge, 'flex leading-none p-2 justify-end relative')}>
+      <PriceBadgeSVG className={styles.priceBadgeShape} />
+
+      <div class='font-bold'>
+        { CURRENCY_SIGN[currency] }
+      </div>
+      <div class='text-4xl font-bold leading-[30px]'>
+        { intPrice }
+      </div>
+      <div>
+        <div class={'font-bold'}>
+          { decimalDigits }
+        </div>
+        <div class='text-xs'>
+          { `per ${period}` }
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/tasks/plan-picker/index.tsx
+++ b/src/tasks/plan-picker/index.tsx
@@ -1,23 +1,2 @@
-type PlanItem = {
-    id: string
-    label: string
-    oldPrice?: number
-    price: number,
-    planBadgeText: string,
-    priceBadge: {
-        currency: string
-        period: 'day' | 'week' | 'month' | 'year'
-        price: number
-        oldPrice?: number
-    }
-}
-
-export type PlanPickerProps = {
-    title?: string
-    defaultPlan?: PlanItem["id"]
-    plans: PlanItem[]
-} & Actionable
-
-export function PlanPickerComponent(props: PlanPickerProps) {
-    return <div></div>
-}
+export * from './PlanPicker';
+export * from './PlanItem';

--- a/src/tasks/plan-picker/styles.module.css
+++ b/src/tasks/plan-picker/styles.module.css
@@ -1,0 +1,51 @@
+.plan {
+  @apply border-2 border-transparent;
+
+  box-shadow: 0 0 1px theme(colors.gray.500);
+}
+
+.withBadge {
+  @apply border-2 border-red-400 bg-red-400/8;
+}
+
+.selected {
+  @apply border-2 border-accent bg-secondary/30;
+}
+
+.withBadge .priceBadgeShape path {
+  fill-opacity: 0.25;
+  fill: theme(colors.red.400);
+}
+
+.priceBadge {
+  width: 105px;
+}
+
+.priceBadgeShape {
+  @apply absolute top-0 right-0;
+}
+
+.priceBadgeShape path {
+  fill: theme(colors.gray.800);
+  fill-opacity: 0.08;
+}
+
+.oldPrice {
+  @apply text-gray-500 text-sm line-through;
+}
+
+.oldPeriodPrice {
+  position: relative;
+  text-decoration: none;
+}
+
+.oldPeriodPrice::before {
+  @apply bg-red-400;
+
+  content: '';
+  position: absolute;
+  left: 0;
+  top: calc(50% - 1px);
+  height: 2px;
+  width: 100%;
+}

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,5 +1,5 @@
 // Actionable is an optional type for adding 2-way-data binding to your own element
 type Actionable = {
-    value?: string | string[]
-    onUpdate?: (payload: string | string[]) => void
+  value?: string | string[]
+  onUpdate: (payload: string | string[]) => void
 }

--- a/src/utils/money.ts
+++ b/src/utils/money.ts
@@ -1,0 +1,9 @@
+import { Currency } from '@/common/constants';
+
+
+export const formatPrice = (price: number, currency: Currency) => {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency,
+  }).format(price);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -973,6 +973,11 @@ chokidar@^3.5.3:
   optionalDependencies:
     fsevents "~2.3.2"
 
+classnames@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
+  integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
+
 clean-stack@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"


### PR DESCRIPTION
- Изменил интерфейс `PlanItem` - вынес `currency` на уровень повыше, до этого был внутри `priceBadge`
- Добавил зависимость `classnames` (утилити пакет для работы с классами)
- В фигме не было состояния для выбранного плана, добавил стили на свое усмотрение, выбранные планы выглядят так:

выбран 1 план
<img width="492" alt="image" src="https://github.com/AndreyRaih/flowly-ui/assets/35048864/55ea9e38-62c7-4b1c-abaf-e300a1324531">

выбран 2 план с меткой MOST POPULAR
<img width="492" alt="image" src="https://github.com/AndreyRaih/flowly-ui/assets/35048864/8a7d6026-fb20-456a-b402-44b4a7edeaef">